### PR TITLE
Add location permission handling to "my location" button

### DIFF
--- a/resources/js/Pages/Index.tsx
+++ b/resources/js/Pages/Index.tsx
@@ -116,6 +116,7 @@ export default function Index({ gasStations }: IndexProps) {
                 hasLocation={!!position}
                 loading={loading}
                 error={error}
+                permission={permission}
             />
 
             {/* Location Permission Dialog */}

--- a/resources/js/components/MyLocationButton.tsx
+++ b/resources/js/components/MyLocationButton.tsx
@@ -8,6 +8,7 @@ interface MyLocationButtonProps {
     hasLocation: boolean;
     loading: boolean;
     error: GeolocationPositionError | null;
+    permission: PermissionState | null;
 }
 
 export default function MyLocationButton({
@@ -16,7 +17,13 @@ export default function MyLocationButton({
     hasLocation,
     loading,
     error,
+    permission,
 }: MyLocationButtonProps) {
+    // Only show the button if permission is granted
+    if (permission !== "granted") {
+        return null;
+    }
+
     const getButtonVariant = () => {
         if (error) return "destructive";
         if (hasLocation) return "default";


### PR DESCRIPTION
This pull request introduces a new `permission` prop to the `MyLocationButton` component to handle location permission states more effectively. The changes ensure that the button is only displayed when the location permission is granted.